### PR TITLE
markdown 3.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "Markdown" %}
-{% set version = "3.3.4" %}
-{% set sha256 = "31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49" %}
+{% set version = "3.4.1" %}
+{% set sha256 = "3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<37]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
   entry_points:
     - markdown_py = markdown.__main__:run
@@ -20,28 +21,33 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - importlib-metadata
     - python
+    - importlib-metadata >=4.4  # [py<310]
 
 test:
   imports:
     - markdown
     - markdown.extensions
+  requires:
+    - pip
   commands:
+    - pip check
     - markdown_py -h
 
 about:
-  home: https://pythonhosted.org/Markdown/
+  home: https://github.com/Python-Markdown/markdown
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.md
-  summary: 'Python implementation of Markdown.'
+  summary: Python implementation of Markdown.
   description: |
     This is a Python implementation of John Gruber’s Markdown. It is almost
     completely compliant with the reference implementation, though there are a
     few very minor differences.
-  doc_url: http://pythonhosted.org/Markdown/
+  doc_url: https://python-markdown.github.io/
   dev_url: https://github.com/Python-Markdown/markdown
 
 extra:


### PR DESCRIPTION
**Jira ticket:** [PKG-921](https://anaconda.atlassian.net/browse/PKG-921) (markdown 3.4.1)

**The upstream data:**
[Diff between the latest and previous upstream releases](https://github.com/Python-Markdown/markdown/compare/3.3.4...3.4.1)
License: https://github.com/Python-Markdown/markdown/blob/master/LICENSE.md
Requirements:
 * setup.py:  https://github.com/Python-Markdown/markdown/blob/3.4.1/setup.py
 * pyproject.toml:  https://github.com/Python-Markdown/markdown/blob/3.4.1/pyproject.toml

**_Actions:_**

1. Skip `py<37`
2. Add missing packages to `host`
3. Fix pinning and constraint for `importlib-metadata`
4. Add p`ip check`
5. Update home and doc urls

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: other_key_deps | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 3.4.1
 * Release on PyPi:
    * version: 3.4.1
    * date: 2022-07-15T19:15:38
* [PyPi history](https://pypi.org/project/markdown/#history)
 * Popularity: 
    * 3 months downloads: 855051.0
    * All time:  4003078 downloads -  markdown  3.4.1  Python implementation of Markdown.  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/Python-Markdown/markdown/tree/3.4.1 exists
7. - [x] Check the pinnings
9. - [x] Additional research
    https://github.com/Python-Markdown/markdown/issues
10. - [x] `dev_url`:
    https://github.com/Python-Markdown/markdown
12. - [x] Verify that the `build_number` is correct
13. - [x] Verify if the package needs `setuptools`
14. - [x] Verify if the package needs `wheel`
15. - [x] `pip` in test
16. - x ] Verify the test section
17. - [x] Verify if the package is `architecture specific`
18. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
19.  - [x] license_file: LICENSE.md is present

20. - [x] license_family BSD is present
21. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check dependency issues:**

<details>
../aggregate/markdown-feedstock/recipe/meta.yaml
Dependencies: ['importlib-metadata', 'pip', 'python']


noarch:

</details>

**Package Build Score: 18**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/markdown-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/markdown-feedstock/tree/3.4.1)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/markdown)
* [Diff between upstream and feature branch](https://github.com/conda-forge/markdown-feedstock/compare/main...AnacondaRecipes:3.4.1)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/markdown-feedstock/compare/master...AnacondaRecipes:3.4.1)
* [The last merged PRs](https://github.com/AnacondaRecipes/markdown-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 3.4.1 git@github.com:AnacondaRecipes/markdown-feedstock.git
```
