### PR TITLE
markdown 3.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=77.0
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
 {% set name = "Markdown" %}
-{% set version = "3.4.1" %}
-{% set sha256 = "3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff" %}
+{% set version = "3.8" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name | lower }}-{{ version }}.tar.gz
+  sha256: 7df81e63f0df5c4b24b7d156eb81e4690595239b7d70937d0409f1b0de319c6f
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<39]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
   entry_points:
     - markdown_py = markdown.__main__:run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<39]
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv"
   entry_points:
     - markdown_py = markdown.__main__:run
 


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7835](https://anaconda.atlassian.net/browse/PKG-7835)
- [Upstream repository](https://github.com/Python-Markdown/markdown/tree/3.8)
- [Upstream changelog/diff](https://github.com/Python-Markdown/markdown/releases)

### Explanation of changes:

- Update version and sha
- Update python version skip and build script
- Update setuptools pinning


[PKG-7835]: https://anaconda.atlassian.net/browse/PKG-7835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ