### PR TITLE
markdown 3.10.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Markdown" %}
-{% set version = "3.10" %}
+{% set version = "3.10.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,14 +7,14 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name | lower }}-{{ version }}.tar.gz
-  sha256: 37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e
+  sha256: 994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950
 
 build:
   number: 0
-  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
   entry_points:
     - markdown_py = markdown.__main__:run
+  skip: true  # [py<310]
 
 requirements:
   host:
@@ -23,7 +23,6 @@ requirements:
     - setuptools >=77.0
   run:
     - python
-    - importlib-metadata >=4.4  # [py<310]
 
 test:
   imports:


### PR DESCRIPTION
markdown 3.10.2 

**Destination channel:** Defaults

### Links

- [PKG-15177]
- dev_url:        https://github.com/Python-Markdown/markdown/tree/3.10.2
- conda_forge:    https://github.com/conda-forge/markdown-feedstock
- pypi:           https://pypi.org/project/markdown/3.10.2
- pypi inspector: https://inspector.pypi.io/project/markdown/3.10.2

### Explanation of changes:

- new version number


[PKG-15177]: https://anaconda.atlassian.net/browse/PKG-15177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ